### PR TITLE
Fix: Use consistent build directory for nix profile upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,15 @@ jobs:
       - name: Deploy to production
         if: success()
         run: |
-          echo "Updating nix profile..."
+          # Use consistent build directory so nix profile upgrade works
+          echo "Syncing to consistent build directory..."
+          rm -rf /build/test-app/*
+          rm -rf /build/test-app/.??* 2>/dev/null || true
+          rsync -av --exclude='.git' --exclude='node_modules' --exclude='result' . /build/test-app/
+          cd /build/test-app
+          
+          echo "Building and updating nix profile..."
+          nix build .#test-app
           nix profile remove test-app 2>/dev/null || true
           nix profile install .#test-app
           

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,10 @@ const server = Bun.serve({
         </style>
       </head>
       <body>
-        <div class="emoji">🎯</div>
+        <div class="emoji">🚀</div>
         <div class="info">
           <p>Test App Running on Port 3001</p>
-          <p>Successfully Auto-deployed via Polkit!</p>
+          <p>FIXED: Auto-deployed via Polkit!</p>
           <p>Deployed at: ${new Date().toISOString()}</p>
         </div>
       </body>


### PR DESCRIPTION
## The Problem
The nix profile wasn't upgrading properly because each CI run used a different directory. This meant the profile saw it as a different package each time.

## The Solution
Use a consistent build directory (/build/test-app) like slipbox does. This ensures nix profile recognizes it as the same package and can upgrade it properly.

## Changes
- Copy code to /build/test-app before building
- Build and install from that consistent location
- Change emoji to 🚀 to verify deployment works

This should finally make the full CI/CD pipeline work correctly!